### PR TITLE
feat: implement command line interface using lexopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "achitek-ls"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "lexopt",
  "lsp-server",
  "lsp-types",
  "ropey",
@@ -108,6 +109,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "lexopt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
+lexopt = "0.3.2"
 anyhow = "1.0.102"
 thiserror = "2.0.18"
 lsp-server = "0.7.9"

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,8 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         craneLib = crane.mkLib pkgs;
-        serverCrate = craneLib.crateNameFromCargoToml {
-          cargoToml = ./server/Cargo.toml;
+        achitekLsCrate = craneLib.crateNameFromCargoToml {
+          cargoToml = ./Cargo.toml;
         };
 
         nix-lsp-server = nil.packages.${system}.nil;
@@ -35,7 +35,7 @@
           src = craneLib.cleanCargoSource ./.;
 
           pname = "achitek-ls";
-          inherit (serverCrate) version;
+          inherit (achitekLsCrate) version;
           strictDeps = true;
 
           nativeBuildInputs = [ pkgs.pkg-config ];
@@ -69,7 +69,7 @@
           commonArgs
           // {
             inherit cargoArtifacts;
-            cargoExtraArgs = "-p server --bin achitek-ls";
+            cargoExtraArgs = "--bin achitek-ls";
           }
         );
       in

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,0 +1,62 @@
+use lexopt::{
+    Arg::{Long, Short},
+    Parser,
+};
+use std::path::PathBuf;
+
+/// Communication channel used by the language server.
+pub enum CommunicationsChannel {
+    /// Use standard input and standard output for JSON-RPC messages.
+    Stdio,
+    /// Use a named pipe on Windows or a Unix socket file on Linux and macOS.
+    Pipe { path: PathBuf },
+    /// Use a TCP socket listening on the given port.
+    Socket { port: u16 },
+    /// Use Node.js IPC when the server is launched from a Node process.
+    NodeIpc,
+}
+
+/// Command line arguments
+pub struct Args {
+    /// The version of this binary as defined in Cargo.toml
+    pub version: String,
+    /// Communication channel selected for the language server.
+    pub channel: Option<CommunicationsChannel>,
+}
+
+const HELP_TEXT: &str = r#"
+Usage: achitek-ls [ARGS]
+
+ARGS:
+  -v, --version  Print version
+      --stdio    Uses stdio as the communication channel
+  -h, --help     Print help
+"#;
+
+/// Parses command-line arguments into language server configuration.
+///
+/// Prints help or version information and exits the process when `--help`,
+/// `-h`, `--version`, or `-v` is supplied.
+pub fn parse() -> Result<Args, lexopt::Error> {
+    let mut version = "".to_string();
+    let mut channel = None;
+    let mut parser = Parser::from_env();
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Short('v') | Long("version") => {
+                version = env!("CARGO_PKG_VERSION").to_string();
+                println!("achitek-ls {version}");
+                std::process::exit(0);
+            }
+            Short('h') | Long("help") => {
+                println!("{HELP_TEXT}");
+                std::process::exit(0);
+            }
+            Long("stdio") => channel = Some(CommunicationsChannel::Stdio),
+            _ => return Err(arg.unexpected()),
+        }
+    }
+
+    Ok(Args { version, channel })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! Lib
 
 mod analysis;
+#[doc(hidden)]
+pub mod arguments;
 mod server;
 mod syntax;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
-fn main() {
-    println!("Hello, world!");
+use achitek_ls::arguments;
+
+fn main() -> Result<(), lexopt::Error> {
+    let _args = arguments::parse()?;
+
+    Ok(())
 }


### PR DESCRIPTION
closes: #4

It's important to note that `lextopt` was chosen over `clap` due to overhead (contribution to binary size) and build time as outlined in the following [benchmark](https://github.com/rosetta-rs/argparse-rosetta-rs).

**Comparison:**

Name | Overhead (release) | Build (debug) | Parse (release) | Invalid UTF-8  | Version
-- | -- | -- | -- | -- | -- 
clap | 574 KiB | 3s (full)170ms (incremental) | 2ms | Y   | v4.5.60
lexopt | 37 KiB | 329ms (full)124ms (incremental) | 2ms | Y   | v0.3.2

