### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/achitek-org/achitek-ls/compare/v0.1.0...v0.1.1)
+
+### 🐛 Bug Fixes
+
+
+- Default to stdio if communications channel not provided - ([c69e8d3](https://github.com/achitek-org/achitek-ls/commit/c69e8d3aa832da603dc6ed9a6588f0d812c8b658))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Lint - ([b1a5e2d](https://github.com/achitek-org/achitek-ls/commit/b1a5e2da3d419f8ed0cf37087a3e49fde040c0d6))
+- Update github token for release-plz release - ([537e241](https://github.com/achitek-org/achitek-ls/commit/537e241f58aad789c60e4068c934feb3cf2e7964))
+
+
 ## [0.1.0]
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "achitek-ls"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "achitek-ls"
-version = "0.1.0"
+version = "0.1.1"
 edition = '2024'
 rust-version = "1.90.0"
 description = "achitekfile language server"


### PR DESCRIPTION



## 🤖 New release

* `achitek-ls`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/achitek-org/achitek-ls/compare/v0.1.0...v0.1.1)

### 🐛 Bug Fixes


- Default to stdio if communications channel not provided - ([c69e8d3](https://github.com/achitek-org/achitek-ls/commit/c69e8d3aa832da603dc6ed9a6588f0d812c8b658))

### ⚙️ Miscellaneous Tasks


- Lint - ([b1a5e2d](https://github.com/achitek-org/achitek-ls/commit/b1a5e2da3d419f8ed0cf37087a3e49fde040c0d6))
- Update github token for release-plz release - ([537e241](https://github.com/achitek-org/achitek-ls/commit/537e241f58aad789c60e4068c934feb3cf2e7964))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).