### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "achitek-ls"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
- "achitekfile 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "achitekfile 0.2.0",
  "anyhow",
  "indoc",
  "lexopt",
@@ -33,22 +33,22 @@ dependencies = [
 [[package]]
 name = "achitekfile"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704393805c8893b883a2ef18c98e447fcc3c56391452358025a23697de6117a7"
 dependencies = [
- "achitek-source",
- "indoc",
  "regex",
- "serde",
  "tree-sitter",
  "tree-sitter-achitekfile",
 ]
 
 [[package]]
 name = "achitekfile"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704393805c8893b883a2ef18c98e447fcc3c56391452358025a23697de6117a7"
+version = "0.3.0"
 dependencies = [
+ "achitek-source",
+ "indoc",
  "regex",
+ "serde",
  "tree-sitter",
  "tree-sitter-achitekfile",
 ]

--- a/crates/achitek-ls/CHANGELOG.md
+++ b/crates/achitek-ls/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/achitek-org/achitek-ls/compare/achitek-ls-v0.1.1...achitek-ls-v0.2.0)
+
+### ⛰️ Features
+
+
+- *(ls)* Add tera diagnostic styling & capture prompt variables in file paths - ([3bf5007](https://github.com/achitek-org/achitek-ls/commit/3bf50075bc0fe9efebd666a7315de30658e3a42a))
+- *(ls)* Implement first pass at tera code actions - ([d947886](https://github.com/achitek-org/achitek-ls/commit/d94788683436003b19394d390155ad0fb07b6a0d))
+- *(ls)* Implement rename - ([accc384](https://github.com/achitek-org/achitek-ls/commit/accc3840cbca98e85ec93662c26c3d4af55c0d14))
+- *(ls)* Implemenet go-to-definition from tera template to achitekfile - ([51831e6](https://github.com/achitek-org/achitek-ls/commit/51831e6c6b25dfa7c7fe072cdfacdac74b3ed63c))
+- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))
+
+### 🐛 Bug Fixes
+
+
+- *(ls)* Dismiss tera builtins as diagnostic errors - ([81fc0df](https://github.com/achitek-org/achitek-ls/commit/81fc0df6107b5eed55faaebf4f465849beb89d4b))
+
+### 🚜 Refactor
+
+
+- *(ls)* Remove code-actions - ([417ca00](https://github.com/achitek-org/achitek-ls/commit/417ca00a75499891b05cd74eb21655b78c525587))
+- *(ls)* Split editor features into modules - ([c4d900e](https://github.com/achitek-org/achitek-ls/commit/c4d900ec837bc5d0d9fcff6e94adeed670e1b1b7))
+- *(ls)* Use achitekfile parser types - ([ed0cfbd](https://github.com/achitek-org/achitek-ls/commit/ed0cfbdf711b413dac03127ff856d9c4a7e7a8b0))
+- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- *(ls)* Clean up diagnostic publishing in handlers - ([3e028e2](https://github.com/achitek-org/achitek-ls/commit/3e028e296a0e27e196f8f99718d17150d5264398))
+- *(ls)* Refactor hover and completion editor features into separate module - ([dec12af](https://github.com/achitek-org/achitek-ls/commit/dec12af2bc9c3932195b4a29bb2346345b59d495))
+- *(ls)* Begin using achitefile analysis semantic model - ([df7c340](https://github.com/achitek-org/achitek-ls/commit/df7c34015e10752497b2d1f5de01060ae2327409))
+- *(ls)* Implement project diagnostics - ([335c62e](https://github.com/achitek-org/achitek-ls/commit/335c62e430a6aa1656a5dd456bd0cebf4381e407))
+- *(ls)* Implement ProjectContext that owns the repeated project lookup/source-loading behavior - ([8ac91a1](https://github.com/achitek-org/achitek-ls/commit/8ac91a127fbf517aa7ba82e3b9706058b0bbc1c2))
+- Pass server state to request handlers - ([3ac50b0](https://github.com/achitek-org/achitek-ls/commit/3ac50b0abd47985f3141bdc2ecbb10c4ab89b0e6))
+- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
+
+
 ## [0.1.1](https://github.com/achitek-org/achitek-ls/compare/v0.1.0...v0.1.1)
 
 ### 🐛 Bug Fixes

--- a/crates/achitek-ls/Cargo.toml
+++ b/crates/achitek-ls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "achitek-ls"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "achitekfile language server"

--- a/crates/achitek-ls/src/lsp/project_diagnostics.rs
+++ b/crates/achitek-ls/src/lsp/project_diagnostics.rs
@@ -157,7 +157,7 @@ fn template_path_references(path: &Path, uri: &Uri) -> Vec<TemplateReference> {
         return Vec::new();
     };
 
-    utils::template_references_in_source(file_name, uri)
+    utils::template_references_in_path(file_name, uri)
 }
 
 fn template_paths(root: &Path) -> anyhow::Result<Vec<PathBuf>> {

--- a/crates/achitek-ls/src/server/utils.rs
+++ b/crates/achitek-ls/src/server/utils.rs
@@ -114,6 +114,33 @@ pub(crate) fn is_template_expression_position(source: &str, position: Position) 
 }
 
 pub(crate) fn template_references_in_source(source: &str, uri: &Uri) -> Vec<TemplateReference> {
+    let Ok(analysis) = terafile::analyze(source) else {
+        return lexical_template_references_in_source(source, uri);
+    };
+    let bindings = analysis
+        .file()
+        .bindings()
+        .iter()
+        .map(|binding| binding.value.name.as_str())
+        .collect::<Vec<_>>();
+
+    analysis
+        .file()
+        .variable_references()
+        .iter()
+        .filter(|reference| !bindings.contains(&reference.value.root.as_str()))
+        .map(|reference| TemplateReference {
+            name: reference.value.root.clone(),
+            location: Location::new(uri.clone(), tera_range_to_lsp(reference.range)),
+        })
+        .collect()
+}
+
+pub(crate) fn template_references_in_path(source: &str, uri: &Uri) -> Vec<TemplateReference> {
+    lexical_template_references_in_source(source, uri)
+}
+
+fn lexical_template_references_in_source(source: &str, uri: &Uri) -> Vec<TemplateReference> {
     let mut references = Vec::new();
 
     for (row, line) in source.lines().enumerate() {
@@ -170,6 +197,20 @@ pub(crate) fn template_references_in_source(source: &str, uri: &Uri) -> Vec<Temp
     }
 
     references
+}
+
+fn tera_range_to_lsp(range: terafile::TextRange) -> Range {
+    Range {
+        start: tera_position_to_lsp(range.start),
+        end: tera_position_to_lsp(range.end),
+    }
+}
+
+fn tera_position_to_lsp(position: terafile::TextPosition) -> Position {
+    Position {
+        line: u32::try_from(position.line).expect("line should fit into u32"),
+        character: u32::try_from(position.byte).expect("column should fit into u32"),
+    }
 }
 
 fn tera_reference_context(line: &str, start: usize, end: usize) -> bool {
@@ -428,6 +469,44 @@ mod test {
         .collect::<Vec<_>>();
 
         assert_eq!(references, vec!["kind", "kind"]);
+        Ok(())
+    }
+
+    #[test]
+    fn template_references_skip_functions_filters_kwargs_and_string_contents() -> anyhow::Result<()>
+    {
+        let uri = "file:///template.tera".parse()?;
+        let references = template_references_in_source(
+            r#"Copyright {{now() | date(format="%Y")}} {{author}}"#,
+            &uri,
+        )
+        .into_iter()
+        .map(|reference| reference.name)
+        .collect::<Vec<_>>();
+
+        assert_eq!(references, vec!["author"]);
+        Ok(())
+    }
+
+    #[test]
+    fn template_references_skip_local_bindings() -> anyhow::Result<()> {
+        let uri = "file:///template.tera".parse()?;
+        let references = template_references_in_source(
+            indoc::indoc! {r#"
+                {% for item in items %}
+                  {{ item }}
+                  {{ loop.index }}
+                {% endfor %}
+                {% set title = project_name %}
+                {{ title }}
+            "#},
+            &uri,
+        )
+        .into_iter()
+        .map(|reference| reference.name)
+        .collect::<Vec<_>>();
+
+        assert_eq!(references, vec!["items", "project_name"]);
         Ok(())
     }
 }

--- a/crates/achitek-source/CHANGELOG.md
+++ b/crates/achitek-source/CHANGELOG.md
@@ -1,3 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.1.0]
+
+### 🚜 Refactor
+
+
+- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
+- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
+

--- a/crates/achitekfile/CHANGELOG.md
+++ b/crates/achitekfile/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/achitek-org/achitek-ls/compare/achitekfile-v0.2.0...achitekfile-v0.3.0)
+
+### ⛰️ Features
+
+
+- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))
+
+### 🚜 Refactor
+
+
+- *(achitekfile)* Lower syntax into model - ([1eba206](https://github.com/achitek-org/achitek-ls/commit/1eba206d577b525654701f8ef3131aa7a0328ad1))
+- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
+
+
 ## [0.2.0](https://github.com/achitek-org/achitekfile/compare/v0.1.0...v0.2.0)
 
 ### ⛰️ Features

--- a/crates/achitekfile/Cargo.toml
+++ b/crates/achitekfile/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 keywords = ["achitek", "parser", "tree-sitter", "dsl", "diagnostics"]
 categories = ["parser-implementations", "development-tools"]
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/terafile/CHANGELOG.md
+++ b/crates/terafile/CHANGELOG.md
@@ -1,3 +1,25 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.1.1]
+
+### ⛰️ Features
+
+
+- *(terafile)* Collect diagnostics - ([5b0e058](https://github.com/achitek-org/achitek-ls/commit/5b0e0588cf4e36acdebc29841133dfbeb7f259de))
+- *(terafile)* Implement analysis - ([ce13c02](https://github.com/achitek-org/achitek-ls/commit/ce13c02fbce82909c6bed602db659cb5f02a221f))
+- *(terafile)* Implement diagnostics - ([94bf3e6](https://github.com/achitek-org/achitek-ls/commit/94bf3e6d95dec8c9f3a559e9956698472b987a2e))
+
+### 🚜 Refactor
+
+
+- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
+- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
+- Initial tera parser - ([131b4e2](https://github.com/achitek-org/achitek-ls/commit/131b4e2ce9189ddd537a9dce26a3a9d5e251e05f))
+


### PR DESCRIPTION



## 🤖 New release

* `achitek-source`: 0.1.0
* `achitekfile`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `terafile`: 0.1.1
* `achitek-ls`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `achitekfile` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum achitekfile::Severity, previously in file /tmp/.tmpE9BUmj/achitekfile/src/diagnostics.rs:723

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct achitekfile::model::Spanned, previously in file /tmp/.tmpE9BUmj/achitekfile/src/model.rs:71
  struct achitekfile::TextRange, previously in file /tmp/.tmpE9BUmj/achitekfile/src/diagnostics.rs:787
  struct achitekfile::TextPosition, previously in file /tmp/.tmpE9BUmj/achitekfile/src/diagnostics.rs:754
```

### ⚠ `achitek-ls` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Args.log_file in /tmp/.tmpjJze5b/achitek-ls/crates/achitek-ls/src/arguments.rs:44
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `achitek-source`

<blockquote>

## [0.1.0]

### 🚜 Refactor


- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
</blockquote>

## `achitekfile`

<blockquote>

## [0.3.0](https://github.com/achitek-org/achitek-ls/compare/achitekfile-v0.2.0...achitekfile-v0.3.0)

### ⛰️ Features


- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))

### 🚜 Refactor


- *(achitekfile)* Lower syntax into model - ([1eba206](https://github.com/achitek-org/achitek-ls/commit/1eba206d577b525654701f8ef3131aa7a0328ad1))
- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))

### ⚙️ Miscellaneous Tasks


- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
</blockquote>

## `terafile`

<blockquote>

## [0.1.1]

### ⛰️ Features


- *(terafile)* Collect diagnostics - ([5b0e058](https://github.com/achitek-org/achitek-ls/commit/5b0e0588cf4e36acdebc29841133dfbeb7f259de))
- *(terafile)* Implement analysis - ([ce13c02](https://github.com/achitek-org/achitek-ls/commit/ce13c02fbce82909c6bed602db659cb5f02a221f))
- *(terafile)* Implement diagnostics - ([94bf3e6](https://github.com/achitek-org/achitek-ls/commit/94bf3e6d95dec8c9f3a559e9956698472b987a2e))

### 🚜 Refactor


- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))

### ⚙️ Miscellaneous Tasks


- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
- Initial tera parser - ([131b4e2](https://github.com/achitek-org/achitek-ls/commit/131b4e2ce9189ddd537a9dce26a3a9d5e251e05f))
</blockquote>

## `achitek-ls`

<blockquote>

## [0.2.0](https://github.com/achitek-org/achitek-ls/compare/achitek-ls-v0.1.1...achitek-ls-v0.2.0)

### ⛰️ Features


- *(ls)* Add tera diagnostic styling & capture prompt variables in file paths - ([3bf5007](https://github.com/achitek-org/achitek-ls/commit/3bf50075bc0fe9efebd666a7315de30658e3a42a))
- *(ls)* Implement first pass at tera code actions - ([d947886](https://github.com/achitek-org/achitek-ls/commit/d94788683436003b19394d390155ad0fb07b6a0d))
- *(ls)* Implement rename - ([accc384](https://github.com/achitek-org/achitek-ls/commit/accc3840cbca98e85ec93662c26c3d4af55c0d14))
- *(ls)* Implemenet go-to-definition from tera template to achitekfile - ([51831e6](https://github.com/achitek-org/achitek-ls/commit/51831e6c6b25dfa7c7fe072cdfacdac74b3ed63c))
- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))

### 🐛 Bug Fixes


- *(ls)* Dismiss tera builtins as diagnostic errors - ([81fc0df](https://github.com/achitek-org/achitek-ls/commit/81fc0df6107b5eed55faaebf4f465849beb89d4b))

### 🚜 Refactor


- *(ls)* Remove code-actions - ([417ca00](https://github.com/achitek-org/achitek-ls/commit/417ca00a75499891b05cd74eb21655b78c525587))
- *(ls)* Split editor features into modules - ([c4d900e](https://github.com/achitek-org/achitek-ls/commit/c4d900ec837bc5d0d9fcff6e94adeed670e1b1b7))
- *(ls)* Use achitekfile parser types - ([ed0cfbd](https://github.com/achitek-org/achitek-ls/commit/ed0cfbdf711b413dac03127ff856d9c4a7e7a8b0))
- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))

### ⚙️ Miscellaneous Tasks


- *(ls)* Clean up diagnostic publishing in handlers - ([3e028e2](https://github.com/achitek-org/achitek-ls/commit/3e028e296a0e27e196f8f99718d17150d5264398))
- *(ls)* Refactor hover and completion editor features into separate module - ([dec12af](https://github.com/achitek-org/achitek-ls/commit/dec12af2bc9c3932195b4a29bb2346345b59d495))
- *(ls)* Begin using achitefile analysis semantic model - ([df7c340](https://github.com/achitek-org/achitek-ls/commit/df7c34015e10752497b2d1f5de01060ae2327409))
- *(ls)* Implement project diagnostics - ([335c62e](https://github.com/achitek-org/achitek-ls/commit/335c62e430a6aa1656a5dd456bd0cebf4381e407))
- *(ls)* Implement ProjectContext that owns the repeated project lookup/source-loading behavior - ([8ac91a1](https://github.com/achitek-org/achitek-ls/commit/8ac91a127fbf517aa7ba82e3b9706058b0bbc1c2))
- Pass server state to request handlers - ([3ac50b0](https://github.com/achitek-org/achitek-ls/commit/3ac50b0abd47985f3141bdc2ecbb10c4ab89b0e6))
- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).