### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "achitek-ls"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "achitekfile",
  "anyhow",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "achitekfile"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "achitek-source",
  "indoc",

--- a/crates/achitek-ls/CHANGELOG.md
+++ b/crates/achitek-ls/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/achitek-org/achitek-ls/compare/achitek-ls-v0.1.1...achitek-ls-v0.2.0)
+
+### ⛰️ Features
+
+
+- *(ls)* Capture non terminated if blocks and raise warning if element is missing in choices - ([6fd0751](https://github.com/achitek-org/achitek-ls/commit/6fd0751d5295cc83cd79f8c1f7d1caa5fc7ebbfa))
+- *(ls)* Add tera diagnostic styling & capture prompt variables in file paths - ([3bf5007](https://github.com/achitek-org/achitek-ls/commit/3bf50075bc0fe9efebd666a7315de30658e3a42a))
+- *(ls)* Implement first pass at tera code actions - ([d947886](https://github.com/achitek-org/achitek-ls/commit/d94788683436003b19394d390155ad0fb07b6a0d))
+- *(ls)* Implement rename - ([accc384](https://github.com/achitek-org/achitek-ls/commit/accc3840cbca98e85ec93662c26c3d4af55c0d14))
+- *(ls)* Implemenet go-to-definition from tera template to achitekfile - ([51831e6](https://github.com/achitek-org/achitek-ls/commit/51831e6c6b25dfa7c7fe072cdfacdac74b3ed63c))
+- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))
+
+### 🐛 Bug Fixes
+
+
+- *(ls)* Dismiss tera builtins as diagnostic errors - ([f935d87](https://github.com/achitek-org/achitek-ls/commit/f935d87875f870d1c7c4c7a111e32e4bb5c48240))
+
+### 🚜 Refactor
+
+
+- *(ls)* Remove code-actions - ([417ca00](https://github.com/achitek-org/achitek-ls/commit/417ca00a75499891b05cd74eb21655b78c525587))
+- *(ls)* Split editor features into modules - ([c4d900e](https://github.com/achitek-org/achitek-ls/commit/c4d900ec837bc5d0d9fcff6e94adeed670e1b1b7))
+- *(ls)* Use achitekfile parser types - ([ed0cfbd](https://github.com/achitek-org/achitek-ls/commit/ed0cfbdf711b413dac03127ff856d9c4a7e7a8b0))
+- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
+
+### 🧪 Testing
+
+
+- *(ls)* Move inline rename tests to integration tests - ([e804847](https://github.com/achitek-org/achitek-ls/commit/e80484734c215103d43b7262dd9bead14a525c0a))
+- *(ls)* Move inline references tests to integration tests - ([dc0eb55](https://github.com/achitek-org/achitek-ls/commit/dc0eb55d5b64083f417d23c94cc4efd4517210f5))
+- *(ls)* Move inline did change tests to integration tests - ([872ae47](https://github.com/achitek-org/achitek-ls/commit/872ae471c7c6b105e66dfa634c6642755b4f0acd))
+- *(ls)* Move inline did open tests to integration tests - ([f46b681](https://github.com/achitek-org/achitek-ls/commit/f46b68130cd436fdd72d2f6459713a042d8cd588))
+- *(ls)* Move inline did close tests to integration tests - ([95bcfa8](https://github.com/achitek-org/achitek-ls/commit/95bcfa8c75bc89d4d9275f8ead48524cfaaf3ced))
+- *(ls)* Move inline workspace symbol tests to integration tests - ([5882a7e](https://github.com/achitek-org/achitek-ls/commit/5882a7e665d3c65addf6b39557b1a29addf61680))
+- *(ls)* Move inline definition tests to integration tests - ([23edd90](https://github.com/achitek-org/achitek-ls/commit/23edd90f6dff2eb494b9299a42b5816b719c6a32))
+- *(ls)* Move inline prepare rename tests to integration tests - ([e7a7714](https://github.com/achitek-org/achitek-ls/commit/e7a7714e522f4cd8c7124ab5cb829eeebade9448))
+- *(ls)* Move inline selection range tests to integration tests - ([4e854ee](https://github.com/achitek-org/achitek-ls/commit/4e854eeed1111c8414aff961063954eacd2e5d9c))
+- *(ls)* Move inline formatting tests to integration tests - ([cd80e67](https://github.com/achitek-org/achitek-ls/commit/cd80e67322cfc7931cf8e3a32e625a3e680864f6))
+- *(ls)* Move inline folding range tests to integration tests - ([876d006](https://github.com/achitek-org/achitek-ls/commit/876d0066e693b4c612fa2845291ccd0da1d8a6b3))
+- *(ls)* Move inline document symbol tests to integration tests - ([62e5805](https://github.com/achitek-org/achitek-ls/commit/62e580519347297bc4941b7592dbcc98bbd37ce9))
+- *(ls)* Move inline completion tests to integration tests - ([50b8676](https://github.com/achitek-org/achitek-ls/commit/50b8676d35a7cfd5e878443a00102a8f293cf77c))
+- *(ls)* Move inline hover tests to integration tests - ([dd9e1a0](https://github.com/achitek-org/achitek-ls/commit/dd9e1a0240d90cc5838e7d1e87cd7bb7d63ff4dd))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- *(achitekfile)* Rename parse_tree - ([f24c6e0](https://github.com/achitek-org/achitek-ls/commit/f24c6e010379488173aaadacb85e4a04eda3dd83))
+- *(ls)* Format code - ([e95e11b](https://github.com/achitek-org/achitek-ls/commit/e95e11b33bfceb1d37bd3a426932513d805b8282))
+- *(ls)* Clean up diagnostic publishing in handlers - ([3e028e2](https://github.com/achitek-org/achitek-ls/commit/3e028e296a0e27e196f8f99718d17150d5264398))
+- *(ls)* Refactor hover and completion editor features into separate module - ([dec12af](https://github.com/achitek-org/achitek-ls/commit/dec12af2bc9c3932195b4a29bb2346345b59d495))
+- *(ls)* Begin using achitefile analysis semantic model - ([df7c340](https://github.com/achitek-org/achitek-ls/commit/df7c34015e10752497b2d1f5de01060ae2327409))
+- *(ls)* Implement project diagnostics - ([335c62e](https://github.com/achitek-org/achitek-ls/commit/335c62e430a6aa1656a5dd456bd0cebf4381e407))
+- *(ls)* Implement ProjectContext that owns the repeated project lookup/source-loading behavior - ([8ac91a1](https://github.com/achitek-org/achitek-ls/commit/8ac91a127fbf517aa7ba82e3b9706058b0bbc1c2))
+- Reference achitekfile locally and small refactor in parser - ([927c20e](https://github.com/achitek-org/achitek-ls/commit/927c20edddf28f042bc4bcd99658cea3e3e7ed31))
+- Pass server state to request handlers - ([3ac50b0](https://github.com/achitek-org/achitek-ls/commit/3ac50b0abd47985f3141bdc2ecbb10c4ab89b0e6))
+- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
+
+
 ## [0.1.1](https://github.com/achitek-org/achitek-ls/compare/v0.1.0...v0.1.1)
 
 ### 🐛 Bug Fixes

--- a/crates/achitek-ls/Cargo.toml
+++ b/crates/achitek-ls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "achitek-ls"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "achitekfile language server"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-achitekfile = { version = "0.2.0", path = "../achitekfile" }
+achitekfile = { version = "0.3.0", path = "../achitekfile" }
 terafile = { version = "0.1.1", path = "../terafile" }
 anyhow = "1.0.102"
 lexopt = "0.3.2"

--- a/crates/achitek-source/CHANGELOG.md
+++ b/crates/achitek-source/CHANGELOG.md
@@ -1,3 +1,21 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.1.0]
+
+### 🚜 Refactor
+
+
+- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
+- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- *(achitek-source)* Addresses C-CTOR - ([d602993](https://github.com/achitek-org/achitek-ls/commit/d60299387f07a9fcff63d659839b81bb0b3e0e4f))
+- *(achitek-source)* Addresses C-METADATA - ([6337189](https://github.com/achitek-org/achitek-ls/commit/633718972536efea2089e8e0c3b9614266462070))
+- *(achitek-source)* Addresses C-COMMON-TRAITS - ([459fb52](https://github.com/achitek-org/achitek-ls/commit/459fb52a81a907c778688336792ff44df5f66380))
+- *(achitek-source)* Addresses C-EXAMPLE - ([d28d3c3](https://github.com/achitek-org/achitek-ls/commit/d28d3c3b6157ebbebfc771a97bf9f0eb6fe96419))
+- *(achitek-source)* Addresses C-CRATE-DOC - ([27c9781](https://github.com/achitek-org/achitek-ls/commit/27c97814089229ed9743af3da70b60e4d288ec92))
+

--- a/crates/achitekfile/CHANGELOG.md
+++ b/crates/achitekfile/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/achitek-org/achitek-ls/compare/achitekfile-v0.2.0...achitekfile-v0.3.0)
+
+### ⛰️ Features
+
+
+- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))
+
+### 🚜 Refactor
+
+
+- *(achitekfile)* Lower syntax into model - ([1eba206](https://github.com/achitek-org/achitek-ls/commit/1eba206d577b525654701f8ef3131aa7a0328ad1))
+- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- *(achitekfile)* Rename parse_tree - ([f24c6e0](https://github.com/achitek-org/achitek-ls/commit/f24c6e010379488173aaadacb85e4a04eda3dd83))
+- Reference achitekfile locally and small refactor in parser - ([927c20e](https://github.com/achitek-org/achitek-ls/commit/927c20edddf28f042bc4bcd99658cea3e3e7ed31))
+- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
+
+
 ## [0.2.0](https://github.com/achitek-org/achitekfile/compare/v0.1.0...v0.2.0)
 
 ### ⛰️ Features

--- a/crates/achitekfile/Cargo.toml
+++ b/crates/achitekfile/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 keywords = ["achitek", "parser", "tree-sitter", "dsl", "diagnostics"]
 categories = ["parser-implementations", "development-tools"]
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/terafile/CHANGELOG.md
+++ b/crates/terafile/CHANGELOG.md
@@ -1,3 +1,35 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.1.1]
+
+### ⛰️ Features
+
+
+- *(terafile)* Collect diagnostics - ([5b0e058](https://github.com/achitek-org/achitek-ls/commit/5b0e0588cf4e36acdebc29841133dfbeb7f259de))
+- *(terafile)* Implement analysis - ([ce13c02](https://github.com/achitek-org/achitek-ls/commit/ce13c02fbce82909c6bed602db659cb5f02a221f))
+- *(terafile)* Implement diagnostics - ([94bf3e6](https://github.com/achitek-org/achitek-ls/commit/94bf3e6d95dec8c9f3a559e9956698472b987a2e))
+
+### 🚜 Refactor
+
+
+- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
+- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))
+
+### ⚙️ Miscellaneous Tasks
+
+
+- *(achitekfile)* Rename parse_tree - ([f24c6e0](https://github.com/achitek-org/achitek-ls/commit/f24c6e010379488173aaadacb85e4a04eda3dd83))
+- *(terafile)* Addresses C-EXAMPLE - ([b626e99](https://github.com/achitek-org/achitek-ls/commit/b626e99804e587bb3cba0e5c7e50fe9a8b8d7940))
+- *(terafile)* Addresses M-INIT-BUILDER - ([a4f75fc](https://github.com/achitek-org/achitek-ls/commit/a4f75fc3c844a8043fa1bce81646ddf67bc312d8))
+- *(terafile)* Addresses C-SERDE - ([14af187](https://github.com/achitek-org/achitek-ls/commit/14af187fd0f324d1671ee3660d85eb12bf04078e))
+- *(terafile)* Addresses C-METADATA - ([14e2c98](https://github.com/achitek-org/achitek-ls/commit/14e2c9865a91b4b0f0a5ac179e0d6a2b9bf231e8))
+- *(terafile)* Addresses C-FAILURE - ([50c10ba](https://github.com/achitek-org/achitek-ls/commit/50c10ba27c29c45924219a0adf3f9a2e9fad2668))
+- *(terafile)* Addresses C-LINK - ([f984a71](https://github.com/achitek-org/achitek-ls/commit/f984a71354b5d684e131ec3e77e0810987548e9c))
+- *(terafile)* Addresses M-ERRORS-CANONICAL-STRUCTS - ([ac77df5](https://github.com/achitek-org/achitek-ls/commit/ac77df5c5bafb823fc5a173125b4492a3c1ca836))
+- *(terafile)* Addresses C-COMMON-TRAITS - ([9f92f09](https://github.com/achitek-org/achitek-ls/commit/9f92f091d4e269c6e358ccaff5e03447a1b35c45))
+- *(terafile)* Addresses C-CRATE-DOC - ([ad028c8](https://github.com/achitek-org/achitek-ls/commit/ad028c8ac5cb12e460534c66f70f782470701f43))
+- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
+- Initial tera parser - ([131b4e2](https://github.com/achitek-org/achitek-ls/commit/131b4e2ce9189ddd537a9dce26a3a9d5e251e05f))
+


### PR DESCRIPTION



## 🤖 New release

* `achitek-source`: 0.1.0
* `achitekfile`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `terafile`: 0.1.1
* `achitek-ls`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `achitekfile` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum achitekfile::Severity, previously in file /tmp/.tmppDIEkL/achitekfile/src/diagnostics.rs:723

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function achitekfile::parse_tree, previously in file /tmp/.tmppDIEkL/achitekfile/src/parser.rs:41

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct achitekfile::model::Spanned, previously in file /tmp/.tmppDIEkL/achitekfile/src/model.rs:71
  struct achitekfile::TextRange, previously in file /tmp/.tmppDIEkL/achitekfile/src/diagnostics.rs:787
  struct achitekfile::TextPosition, previously in file /tmp/.tmppDIEkL/achitekfile/src/diagnostics.rs:754
```

### ⚠ `achitek-ls` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Args.log_file in /tmp/.tmpp4VKhQ/achitek-ls/crates/achitek-ls/src/arguments.rs:44
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `achitek-source`

<blockquote>

## [0.1.0]

### 🚜 Refactor


- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))

### ⚙️ Miscellaneous Tasks


- *(achitek-source)* Addresses C-CTOR - ([d602993](https://github.com/achitek-org/achitek-ls/commit/d60299387f07a9fcff63d659839b81bb0b3e0e4f))
- *(achitek-source)* Addresses C-METADATA - ([6337189](https://github.com/achitek-org/achitek-ls/commit/633718972536efea2089e8e0c3b9614266462070))
- *(achitek-source)* Addresses C-COMMON-TRAITS - ([459fb52](https://github.com/achitek-org/achitek-ls/commit/459fb52a81a907c778688336792ff44df5f66380))
- *(achitek-source)* Addresses C-EXAMPLE - ([d28d3c3](https://github.com/achitek-org/achitek-ls/commit/d28d3c3b6157ebbebfc771a97bf9f0eb6fe96419))
- *(achitek-source)* Addresses C-CRATE-DOC - ([27c9781](https://github.com/achitek-org/achitek-ls/commit/27c97814089229ed9743af3da70b60e4d288ec92))
</blockquote>

## `achitekfile`

<blockquote>

## [0.3.0](https://github.com/achitek-org/achitek-ls/compare/achitekfile-v0.2.0...achitekfile-v0.3.0)

### ⛰️ Features


- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))

### 🚜 Refactor


- *(achitekfile)* Lower syntax into model - ([1eba206](https://github.com/achitek-org/achitek-ls/commit/1eba206d577b525654701f8ef3131aa7a0328ad1))
- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))

### ⚙️ Miscellaneous Tasks


- *(achitekfile)* Rename parse_tree - ([f24c6e0](https://github.com/achitek-org/achitek-ls/commit/f24c6e010379488173aaadacb85e4a04eda3dd83))
- Reference achitekfile locally and small refactor in parser - ([927c20e](https://github.com/achitek-org/achitek-ls/commit/927c20edddf28f042bc4bcd99658cea3e3e7ed31))
- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
</blockquote>

## `terafile`

<blockquote>

## [0.1.1]

### ⛰️ Features


- *(terafile)* Collect diagnostics - ([5b0e058](https://github.com/achitek-org/achitek-ls/commit/5b0e0588cf4e36acdebc29841133dfbeb7f259de))
- *(terafile)* Implement analysis - ([ce13c02](https://github.com/achitek-org/achitek-ls/commit/ce13c02fbce82909c6bed602db659cb5f02a221f))
- *(terafile)* Implement diagnostics - ([94bf3e6](https://github.com/achitek-org/achitek-ls/commit/94bf3e6d95dec8c9f3a559e9956698472b987a2e))

### 🚜 Refactor


- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))
- Move shared utils and structs to achitek-source crate - ([9775e3e](https://github.com/achitek-org/achitek-ls/commit/9775e3e183b76cdf77b057d704d1a9e0ca24b5c7))

### ⚙️ Miscellaneous Tasks


- *(achitekfile)* Rename parse_tree - ([f24c6e0](https://github.com/achitek-org/achitek-ls/commit/f24c6e010379488173aaadacb85e4a04eda3dd83))
- *(terafile)* Addresses C-EXAMPLE - ([b626e99](https://github.com/achitek-org/achitek-ls/commit/b626e99804e587bb3cba0e5c7e50fe9a8b8d7940))
- *(terafile)* Addresses M-INIT-BUILDER - ([a4f75fc](https://github.com/achitek-org/achitek-ls/commit/a4f75fc3c844a8043fa1bce81646ddf67bc312d8))
- *(terafile)* Addresses C-SERDE - ([14af187](https://github.com/achitek-org/achitek-ls/commit/14af187fd0f324d1671ee3660d85eb12bf04078e))
- *(terafile)* Addresses C-METADATA - ([14e2c98](https://github.com/achitek-org/achitek-ls/commit/14e2c9865a91b4b0f0a5ac179e0d6a2b9bf231e8))
- *(terafile)* Addresses C-FAILURE - ([50c10ba](https://github.com/achitek-org/achitek-ls/commit/50c10ba27c29c45924219a0adf3f9a2e9fad2668))
- *(terafile)* Addresses C-LINK - ([f984a71](https://github.com/achitek-org/achitek-ls/commit/f984a71354b5d684e131ec3e77e0810987548e9c))
- *(terafile)* Addresses M-ERRORS-CANONICAL-STRUCTS - ([ac77df5](https://github.com/achitek-org/achitek-ls/commit/ac77df5c5bafb823fc5a173125b4492a3c1ca836))
- *(terafile)* Addresses C-COMMON-TRAITS - ([9f92f09](https://github.com/achitek-org/achitek-ls/commit/9f92f091d4e269c6e358ccaff5e03447a1b35c45))
- *(terafile)* Addresses C-CRATE-DOC - ([ad028c8](https://github.com/achitek-org/achitek-ls/commit/ad028c8ac5cb12e460534c66f70f782470701f43))
- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
- Initial tera parser - ([131b4e2](https://github.com/achitek-org/achitek-ls/commit/131b4e2ce9189ddd537a9dce26a3a9d5e251e05f))
</blockquote>

## `achitek-ls`

<blockquote>

## [0.2.0](https://github.com/achitek-org/achitek-ls/compare/achitek-ls-v0.1.1...achitek-ls-v0.2.0)

### ⛰️ Features


- *(ls)* Capture non terminated if blocks and raise warning if element is missing in choices - ([6fd0751](https://github.com/achitek-org/achitek-ls/commit/6fd0751d5295cc83cd79f8c1f7d1caa5fc7ebbfa))
- *(ls)* Add tera diagnostic styling & capture prompt variables in file paths - ([3bf5007](https://github.com/achitek-org/achitek-ls/commit/3bf50075bc0fe9efebd666a7315de30658e3a42a))
- *(ls)* Implement first pass at tera code actions - ([d947886](https://github.com/achitek-org/achitek-ls/commit/d94788683436003b19394d390155ad0fb07b6a0d))
- *(ls)* Implement rename - ([accc384](https://github.com/achitek-org/achitek-ls/commit/accc3840cbca98e85ec93662c26c3d4af55c0d14))
- *(ls)* Implemenet go-to-definition from tera template to achitekfile - ([51831e6](https://github.com/achitek-org/achitek-ls/commit/51831e6c6b25dfa7c7fe072cdfacdac74b3ed63c))
- Introduce workspace - ([757e661](https://github.com/achitek-org/achitek-ls/commit/757e6617cc7402b96fb11737b778f9b42bcf7799))

### 🐛 Bug Fixes


- *(ls)* Dismiss tera builtins as diagnostic errors - ([f935d87](https://github.com/achitek-org/achitek-ls/commit/f935d87875f870d1c7c4c7a111e32e4bb5c48240))

### 🚜 Refactor


- *(ls)* Remove code-actions - ([417ca00](https://github.com/achitek-org/achitek-ls/commit/417ca00a75499891b05cd74eb21655b78c525587))
- *(ls)* Split editor features into modules - ([c4d900e](https://github.com/achitek-org/achitek-ls/commit/c4d900ec837bc5d0d9fcff6e94adeed670e1b1b7))
- *(ls)* Use achitekfile parser types - ([ed0cfbd](https://github.com/achitek-org/achitek-ls/commit/ed0cfbdf711b413dac03127ff856d9c4a7e7a8b0))
- *(terafile)* Consolidate vendored grammar ownership - ([d386b4c](https://github.com/achitek-org/achitek-ls/commit/d386b4c44de641b69e80a77d587aa7b4ff02c3b5))

### 🧪 Testing


- *(ls)* Move inline rename tests to integration tests - ([e804847](https://github.com/achitek-org/achitek-ls/commit/e80484734c215103d43b7262dd9bead14a525c0a))
- *(ls)* Move inline references tests to integration tests - ([dc0eb55](https://github.com/achitek-org/achitek-ls/commit/dc0eb55d5b64083f417d23c94cc4efd4517210f5))
- *(ls)* Move inline did change tests to integration tests - ([872ae47](https://github.com/achitek-org/achitek-ls/commit/872ae471c7c6b105e66dfa634c6642755b4f0acd))
- *(ls)* Move inline did open tests to integration tests - ([f46b681](https://github.com/achitek-org/achitek-ls/commit/f46b68130cd436fdd72d2f6459713a042d8cd588))
- *(ls)* Move inline did close tests to integration tests - ([95bcfa8](https://github.com/achitek-org/achitek-ls/commit/95bcfa8c75bc89d4d9275f8ead48524cfaaf3ced))
- *(ls)* Move inline workspace symbol tests to integration tests - ([5882a7e](https://github.com/achitek-org/achitek-ls/commit/5882a7e665d3c65addf6b39557b1a29addf61680))
- *(ls)* Move inline definition tests to integration tests - ([23edd90](https://github.com/achitek-org/achitek-ls/commit/23edd90f6dff2eb494b9299a42b5816b719c6a32))
- *(ls)* Move inline prepare rename tests to integration tests - ([e7a7714](https://github.com/achitek-org/achitek-ls/commit/e7a7714e522f4cd8c7124ab5cb829eeebade9448))
- *(ls)* Move inline selection range tests to integration tests - ([4e854ee](https://github.com/achitek-org/achitek-ls/commit/4e854eeed1111c8414aff961063954eacd2e5d9c))
- *(ls)* Move inline formatting tests to integration tests - ([cd80e67](https://github.com/achitek-org/achitek-ls/commit/cd80e67322cfc7931cf8e3a32e625a3e680864f6))
- *(ls)* Move inline folding range tests to integration tests - ([876d006](https://github.com/achitek-org/achitek-ls/commit/876d0066e693b4c612fa2845291ccd0da1d8a6b3))
- *(ls)* Move inline document symbol tests to integration tests - ([62e5805](https://github.com/achitek-org/achitek-ls/commit/62e580519347297bc4941b7592dbcc98bbd37ce9))
- *(ls)* Move inline completion tests to integration tests - ([50b8676](https://github.com/achitek-org/achitek-ls/commit/50b8676d35a7cfd5e878443a00102a8f293cf77c))
- *(ls)* Move inline hover tests to integration tests - ([dd9e1a0](https://github.com/achitek-org/achitek-ls/commit/dd9e1a0240d90cc5838e7d1e87cd7bb7d63ff4dd))

### ⚙️ Miscellaneous Tasks


- *(achitekfile)* Rename parse_tree - ([f24c6e0](https://github.com/achitek-org/achitek-ls/commit/f24c6e010379488173aaadacb85e4a04eda3dd83))
- *(ls)* Format code - ([e95e11b](https://github.com/achitek-org/achitek-ls/commit/e95e11b33bfceb1d37bd3a426932513d805b8282))
- *(ls)* Clean up diagnostic publishing in handlers - ([3e028e2](https://github.com/achitek-org/achitek-ls/commit/3e028e296a0e27e196f8f99718d17150d5264398))
- *(ls)* Refactor hover and completion editor features into separate module - ([dec12af](https://github.com/achitek-org/achitek-ls/commit/dec12af2bc9c3932195b4a29bb2346345b59d495))
- *(ls)* Begin using achitefile analysis semantic model - ([df7c340](https://github.com/achitek-org/achitek-ls/commit/df7c34015e10752497b2d1f5de01060ae2327409))
- *(ls)* Implement project diagnostics - ([335c62e](https://github.com/achitek-org/achitek-ls/commit/335c62e430a6aa1656a5dd456bd0cebf4381e407))
- *(ls)* Implement ProjectContext that owns the repeated project lookup/source-loading behavior - ([8ac91a1](https://github.com/achitek-org/achitek-ls/commit/8ac91a127fbf517aa7ba82e3b9706058b0bbc1c2))
- Reference achitekfile locally and small refactor in parser - ([927c20e](https://github.com/achitek-org/achitek-ls/commit/927c20edddf28f042bc4bcd99658cea3e3e7ed31))
- Pass server state to request handlers - ([3ac50b0](https://github.com/achitek-org/achitek-ls/commit/3ac50b0abd47985f3141bdc2ecbb10c4ab89b0e6))
- Update workspace - ([4d67daf](https://github.com/achitek-org/achitek-ls/commit/4d67daf8ded392abaa60ec332a2ee10f3fa4e84b))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).